### PR TITLE
Add info to customVar

### DIFF
--- a/protobufs/sprite.proto
+++ b/protobufs/sprite.proto
@@ -85,6 +85,7 @@ message customVar {
     optional string id = 2;
     optional string name = 3;
     optional string value = 4;
+    repeated string info = 5;
 }
 
 message Sprite {


### PR DESCRIPTION
Adds "info" to custom var. The related PR linked below was [merged](https://github.com/PenguinMod/PenguinMod-Vm/commit/29f6d5b6117047d5c4a1e090ea389cd931cc5c48) before what it added was added here. So this adds an `info` parameter to here.

## Related
* https://github.com/PenguinMod/PenguinMod-Vm/pull/123